### PR TITLE
Use require_once to load the DBLayer class. This file could have been loa

### DIFF
--- a/include/dblayer/common_db.php
+++ b/include/dblayer/common_db.php
@@ -15,27 +15,27 @@ if (!defined('PUN'))
 switch ($db_type)
 {
 	case 'mysql':
-		require PUN_ROOT.'include/dblayer/mysql.php';
+		require_once PUN_ROOT.'include/dblayer/mysql.php';
 		break;
 
 	case 'mysql_innodb':
-		require PUN_ROOT.'include/dblayer/mysql_innodb.php';
+		require_once PUN_ROOT.'include/dblayer/mysql_innodb.php';
 		break;
 
 	case 'mysqli':
-		require PUN_ROOT.'include/dblayer/mysqli.php';
+		require_once PUN_ROOT.'include/dblayer/mysqli.php';
 		break;
 
 	case 'mysqli_innodb':
-		require PUN_ROOT.'include/dblayer/mysqli_innodb.php';
+		require_once PUN_ROOT.'include/dblayer/mysqli_innodb.php';
 		break;
 
 	case 'pgsql':
-		require PUN_ROOT.'include/dblayer/pgsql.php';
+		require_once PUN_ROOT.'include/dblayer/pgsql.php';
 		break;
 
 	case 'sqlite':
-		require PUN_ROOT.'include/dblayer/sqlite.php';
+		require_once PUN_ROOT.'include/dblayer/sqlite.php';
 		break;
 
 	default:


### PR DESCRIPTION
Use require_once to load the DBLayer class. This file could have been loaded an other way.
