### PR TITLE
#668: Change html structure of admin_options.php for issue with old themes and float

### DIFF
--- a/admin_options.php
+++ b/admin_options.php
@@ -437,7 +437,7 @@ generate_admin_menu('options');
 									<td>
 										<label class="conl"><input type="radio" name="form[smilies]" value="1"<?php if ($pun_config['o_smilies'] == '1') echo ' checked="checked"' ?> />&#160;<strong><?php echo $lang_admin_common['Yes'] ?></strong></label>
 										<label class="conl"><input type="radio" name="form[smilies]" value="0"<?php if ($pun_config['o_smilies'] == '0') echo ' checked="checked"' ?> />&#160;<strong><?php echo $lang_admin_common['No'] ?></strong></label>
-										<span class="conl"><?php echo $lang_admin_options['Smilies help'] ?></span>
+										<span class="clearb"><?php echo $lang_admin_options['Smilies help'] ?></span>
 									</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
i changed label so they wrap text and control, and I added class clearb on span following them : http://i.imgur.com/5Z90i.png

( so on old theme where label.conl is a float, it looks the same )

there was also an issue when there was 3 radios buttons ( clicking on first text did nothing, clicking on the second text changed first option, clicking on third text changed second option )

for smtp password since there was one option i used just a label ( which is a block ) : http://i.imgur.com/c0ZPe.png

for default email setting ( on which there was no label ) i used < label> too : http://i.imgur.com/wmMym.png

( link to ticket : http://fluxbb.org/development/core/tickets/668/ )
