### PR TITLE
#710: Fix for SMTP email error

### DIFF
--- a/include/email.php
+++ b/include/email.php
@@ -310,9 +310,7 @@ function smtp_mail($to, $subject, $message, $headers = '')
 	if ($pun_config['o_smtp_user'] != '' && $pun_config['o_smtp_pass'] != '')
 	{
 		// Here we try to determine the *real* hostname (reverse DNS entry preferrably)
-		$local_host = 'localhost.localdomain';
 
-	
 		$local_host = php_uname('n');
 
 		// Able to resolve name to IP


### PR DESCRIPTION
A simple fix for the ticket 710 with the title 'Error: Unable to send email. SMTP server: 501 Syntactically invalid EHLO argument(s) '
