### PR TITLE
#911 Fix borders in FluxBB 1.2 styles and Technetium in IE11

### DIFF
--- a/style/Cobalt.css
+++ b/style/Cobalt.css
@@ -516,7 +516,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Lithium.css
+++ b/style/Lithium.css
@@ -516,7 +516,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Mercury.css
+++ b/style/Mercury.css
@@ -516,7 +516,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Oxygen.css
+++ b/style/Oxygen.css
@@ -517,7 +517,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Radium.css
+++ b/style/Radium.css
@@ -516,7 +516,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Sulfur.css
+++ b/style/Sulfur.css
@@ -516,7 +516,6 @@ html, body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 	}

--- a/style/Technetium.css
+++ b/style/Technetium.css
@@ -582,7 +582,6 @@ body {
 .pun .blocktable .tclcon {
 	padding: 0 11px 0 12px;
 	overflow: hidden;
-	height: 1%;
 	min-height: 1px;
 	position: relative;
 }


### PR DESCRIPTION
This fixes the issue in Internet Explorer 11.0.1 (not in the original RTM, through, same fix didn't work back then, might have been an issue on my side, but it didn't work), anyway... I assume FluxBB 1.5.5 is ready with this.
