### PR TITLE
Better csrf

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1149,9 +1149,8 @@ function pun_csrf_token()
 	global $pun_user;
 	static $token;
 
-	if (!$token) {
+	if (!isset($token))
 		$token = pun_hash($pun_user['id'].$pun_user['password'].pun_hash(get_remote_address()));
-	}
 
 	return $token;
 }

--- a/include/functions.php
+++ b/include/functions.php
@@ -1147,8 +1147,13 @@ function pun_hash($str)
 function pun_csrf_token()
 {
 	global $pun_user;
+	static $token;
 
-	return pun_hash($pun_user['id'].$pun_user['password'].pun_hash(get_remote_address()));
+	if (!$token) {
+		$token = pun_hash($pun_user['id'].$pun_user['password'].pun_hash(get_remote_address()));
+	}
+
+	return $token;
 }
 
 //

--- a/include/functions.php
+++ b/include/functions.php
@@ -1148,7 +1148,7 @@ function pun_csrf_token()
 {
 	global $pun_user;
 
-	return pun_hash($pun_user['id'].pun_hash(get_remote_address()));
+	return pun_hash($pun_user['id'].$pun_user['password'].pun_hash(get_remote_address()));
 }
 
 //
@@ -2018,7 +2018,7 @@ function url_valid($url)
 //
 function ucp_preg_replace($pattern, $replace, $subject, $callback = false)
 {
-	if($callback) 
+	if($callback)
 		$replaced = preg_replace_callback($pattern, create_function('$matches', 'return '.$replace.';'), $subject);
 	else
 		$replaced = preg_replace($pattern, $replace, $subject);


### PR DESCRIPTION
Include the password hash in the token, before hashing it, so that it is not generateable if the user's IP address is known.

Also, memoize the hash so that it's only generated once.

Any thoughts?