### PR TITLE
#1066 Use CSS to truncate long username when displaying

### DIFF
--- a/style/Air.css
+++ b/style/Air.css
@@ -769,6 +769,14 @@ MAIN POSTS
 	left: 0;
 	overflow: hidden;
 	width: 206px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#postreview .blockpost dt, #punsearch .blockpost dt {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .pun .blockpost dt strong {

--- a/style/Earth.css
+++ b/style/Earth.css
@@ -768,6 +768,14 @@ MAIN POSTS
 	left: 0;
 	overflow: hidden;
 	width: 206px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#postreview .blockpost dt, #punsearch .blockpost dt {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .pun .blockpost dt strong {

--- a/style/Fire.css
+++ b/style/Fire.css
@@ -768,6 +768,14 @@ MAIN POSTS
 	left: 0;
 	overflow: hidden;
 	width: 206px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#postreview .blockpost dt, #punsearch .blockpost dt {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .pun .blockpost dt strong {


### PR DESCRIPTION
Do not display full username on hover because it overlaps other text which can be distracting.