### PR TITLE
Allow disabling X-Frame-Options

### DIFF
--- a/header.php
+++ b/header.php
@@ -19,9 +19,16 @@ header('Pragma: no-cache'); // For HTTP/1.0 compatibility
 // Send the Content-type header in case the web server is setup to send something else
 header('Content-type: text/html; charset=utf-8');
 
-// Prevent site from being embedded in a frame
-$frame_options = defined('FORUM_FRAME_OPTIONS') ? FORUM_FRAME_OPTIONS : 'deny';
-header('X-Frame-Options: '.$frame_options);
+// Prevent site from being embedded in a frame unless FORUM_FRAME_OPTIONS is set to false
+if (defined('FORUM_FRAME_OPTIONS'))
+{
+	if (FORUM_FRAME_OPTIONS)
+		header('X-Frame-Options: '.FORUM_FRAME_OPTIONS);
+}
+else
+{
+	header('X-Frame-Options: deny');
+}
 
 // Load the template
 if (defined('PUN_ADMIN_CONSOLE'))

--- a/header.php
+++ b/header.php
@@ -19,16 +19,15 @@ header('Pragma: no-cache'); // For HTTP/1.0 compatibility
 // Send the Content-type header in case the web server is setup to send something else
 header('Content-type: text/html; charset=utf-8');
 
-// Prevent site from being embedded in a frame unless FORUM_FRAME_OPTIONS is set to false
+// Prevent site from being embedded in a frame unless FORUM_FRAME_OPTIONS is set
+// to a valid X-Frame-Options header value or false
 if (defined('FORUM_FRAME_OPTIONS'))
 {
-	if (FORUM_FRAME_OPTIONS)
+	if (preg_match('/^(?:allow-from|deny|sameorigin)/i', FORUM_FRAME_OPTIONS) === 1)
 		header('X-Frame-Options: '.FORUM_FRAME_OPTIONS);
 }
 else
-{
 	header('X-Frame-Options: deny');
-}
 
 // Load the template
 if (defined('PUN_ADMIN_CONSOLE'))


### PR DESCRIPTION
X-Frame-Options does not have a whitelist "allow" setting.
https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options

This change allows me to define `FORUM_FRAME_OPTIONS` as `false` so I can disable this header.

## Problem

Flux sets the `X-Frame-Options: deny` header by default. The `FORUM_FRAME_OPTIONS` constant enables the user to override the default value of `deny` with another [valid value](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options). Unfortunately, the `allow-from` value *does not work in Chrome*, preventing the forum to be embedded at all.

## Solution

Allow the user to disable the `X-Frame-Options` header all together.

## Proposal

My solution checks:
1. if `FORUM_FRAME_OPTIONS` is truthy (a string) in which case it will set the header to its value (unchanged behavior)
2. else the header will not be set (new)
3. if `FORUM_FRAME_OPTIONS` is not defined, the default remains to output the `deny` header. (unchanged behavior)

```php
# config.php

define('FORUM_FRAME_OPTIONS', 'sameorigin'); // X-Frame-Options: sameorigin
define('FORUM_FRAME_OPTIONS', false); // no X-Frame-Options header is set
```
