### PR TITLE
The prohibition of links in a subject (Ticket 1097)

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -75,7 +75,7 @@ if (isset($_POST['form_sent']))
 			$errors[] = $lang_post['Too long subject'];
 		else if ($pun_config['p_subject_all_caps'] == '0' && is_all_uppercase($subject) && !$pun_user['is_admmod'])
 			$errors[] = $lang_post['All caps subject'];
-        else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
+		else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
 			$errors[] = $lang_common['BBCode error tag url not allowed'];
 	}
 

--- a/edit.php
+++ b/edit.php
@@ -75,6 +75,8 @@ if (isset($_POST['form_sent']))
 			$errors[] = $lang_post['Too long subject'];
 		else if ($pun_config['p_subject_all_caps'] == '0' && is_all_uppercase($subject) && !$pun_user['is_admmod'])
 			$errors[] = $lang_post['All caps subject'];
+        else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
+			$errors[] = $lang_common['BBCode error tag url not allowed'];
 	}
 
 	// Clean up message from POST

--- a/header.php
+++ b/header.php
@@ -173,8 +173,7 @@ if (isset($focus_element))
 
 
 // START SUBST - <pun_page>
-$script_name = preg_replace('/(\?.*)?$/', '', $_SERVER['REQUEST_URI']);
-$tpl_main = str_replace('<pun_page>', htmlspecialchars(basename($script_name, '.php')), $tpl_main);
+$tpl_main = str_replace('<pun_page>', htmlspecialchars(basename($_SERVER['SCRIPT_NAME'], '.php')), $tpl_main);
 // END SUBST - <pun_page>
 
 

--- a/post.php
+++ b/post.php
@@ -84,6 +84,8 @@ if (isset($_POST['form_sent']))
 			$errors[] = $lang_post['Too long subject'];
 		else if ($pun_config['p_subject_all_caps'] == '0' && is_all_uppercase($subject) && !$pun_user['is_admmod'])
 			$errors[] = $lang_post['All caps subject'];
+        else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
+			$errors[] = $lang_common['BBCode error tag url not allowed'];
 	}
 
 	// If the user is logged in we get the username and email from $pun_user

--- a/post.php
+++ b/post.php
@@ -84,7 +84,7 @@ if (isset($_POST['form_sent']))
 			$errors[] = $lang_post['Too long subject'];
 		else if ($pun_config['p_subject_all_caps'] == '0' && is_all_uppercase($subject) && !$pun_user['is_admmod'])
 			$errors[] = $lang_post['All caps subject'];
-        else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
+		else if ($pun_user['g_post_links'] != '1' && preg_match('%(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%', $subject))
 			$errors[] = $lang_common['BBCode error tag url not allowed'];
 	}
 


### PR DESCRIPTION
For $pun_user['g_post_links'] != '1' added prohibitions of links in
subject title (regex: %(?:h\s*t|f)\s*t\s*p\s*(?:s\s*)?:\s*/\s*/%).
Will stop 'http://'... and 'h tt p s://...'.