### PR TITLE
Change admin alert font color to be readable across all themes

### DIFF
--- a/style/imports/base_admin.css
+++ b/style/imports/base_admin.css
@@ -9,7 +9,7 @@
 #adintro p {padding: 10px}
 #adstats dl {padding: 5px 0 10px 5px}
 #adalerts {padding: 10px}
-#adalerts p {padding: 10px; background: #ffffe1; border: 1px solid #dfe6ee}
+#adalerts p {padding: 10px; background: #ffffe1; color: #000000; border: 1px solid #dfe6ee}
 
 #adminconsole fieldset td {text-align: left; padding: 4px; white-space: normal}
 #adminconsole fieldset th {text-align: left; padding: 4px; white-space: normal}


### PR DESCRIPTION
A user on the FluxBB Ticket System pointed out the admin alert font color text was difficult to read on certain themes. This change switches the text to be easier to read across all themes.