### PR TITLE
Add bidi support

### DIFF
--- a/admin_forums.php
+++ b/admin_forums.php
@@ -250,7 +250,7 @@ else if (isset($_GET['edit_forum']))
 								</tr>
 								<tr>
 									<th scope="row"><?php echo $lang_admin_forums['Forum description label'] ?></th>
-									<td><textarea name="forum_desc" rows="3" cols="50" tabindex="2"><?php echo pun_htmlspecialchars($cur_forum['forum_desc']) ?></textarea></td>
+									<td><textarea dir="auto" name="forum_desc" rows="3" cols="50" tabindex="2"><?php echo pun_htmlspecialchars($cur_forum['forum_desc']) ?></textarea></td>
 								</tr>
 								<tr>
 									<th scope="row"><?php echo $lang_admin_forums['Category label'] ?></th>

--- a/admin_options.php
+++ b/admin_options.php
@@ -249,7 +249,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Board desc label'] ?></th>
 									<td>
-										<textarea name="form[board_desc]" cols="60" rows="3"><?php echo pun_htmlspecialchars($pun_config['o_board_desc']) ?></textarea>
+										<textarea dir="auto" name="form[board_desc]" cols="60" rows="3"><?php echo pun_htmlspecialchars($pun_config['o_board_desc']) ?></textarea>
 										<span><?php echo $lang_admin_options['Board desc help'] ?></span>
 									</td>
 								</tr>
@@ -584,7 +584,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Menu items label'] ?></th>
 									<td>
-										<textarea name="form[additional_navlinks]" rows="3" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_additional_navlinks']) ?></textarea>
+										<textarea dir="auto" name="form[additional_navlinks]" rows="3" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_additional_navlinks']) ?></textarea>
 										<span><?php echo $lang_admin_options['Menu items help'] ?></span>
 									</td>
 								</tr>
@@ -644,7 +644,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Mailing list label'] ?></th>
 									<td>
-										<textarea name="form[mailing_list]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_mailing_list']) ?></textarea>
+										<textarea dir="auto" name="form[mailing_list]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_mailing_list']) ?></textarea>
 										<span><?php echo $lang_admin_options['Mailing list help'] ?></span>
 									</td>
 								</tr>
@@ -808,7 +808,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Rules label'] ?></th>
 									<td>
-										<textarea name="form[rules_message]" rows="10" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_rules_message']) ?></textarea>
+										<textarea dir="auto" name="form[rules_message]" rows="10" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_rules_message']) ?></textarea>
 										<span><?php echo $lang_admin_options['Rules help'] ?></span>
 									</td>
 								</tr>
@@ -841,7 +841,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Announcement message label'] ?></th>
 									<td>
-										<textarea name="form[announcement_message]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_announcement_message']) ?></textarea>
+										<textarea dir="auto" name="form[announcement_message]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_announcement_message']) ?></textarea>
 										<span><?php echo $lang_admin_options['Announcement message help'] ?></span>
 									</td>
 								</tr>
@@ -865,7 +865,7 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Maintenance message label'] ?></th>
 									<td>
-										<textarea name="form[maintenance_message]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_maintenance_message']) ?></textarea>
+										<textarea dir="auto" name="form[maintenance_message]" rows="5" cols="55"><?php echo pun_htmlspecialchars($pun_config['o_maintenance_message']) ?></textarea>
 										<span><?php echo $lang_admin_options['Maintenance message help'] ?></span>
 									</td>
 								</tr>

--- a/db_update.php
+++ b/db_update.php
@@ -522,7 +522,7 @@ if (empty($stage))
 						<p><?php echo $lang_update['Maintenance message info'] ?></p>
 						<div class="txtarea">
 							<label class="required"><strong><?php echo $lang_update['Maintenance message'] ?> <span><?php echo $lang_update['Required'] ?></span></strong><br />
-							<textarea name="req_maintenance_message" rows="4" cols="65"><?php echo pun_htmlspecialchars($pun_config['o_maintenance_message']) ?></textarea><br /></label>
+							<textarea dir="auto" name="req_maintenance_message" rows="4" cols="65"><?php echo pun_htmlspecialchars($pun_config['o_maintenance_message']) ?></textarea><br /></label>
 						</div>
 					</div>
 				</fieldset>

--- a/edit.php
+++ b/edit.php
@@ -228,7 +228,7 @@ else if (isset($_POST['preview']))
 <?php if ($can_edit_subject): ?>						<label class="required"><strong><?php echo $lang_common['Subject'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br />
 						<input class="longinput" type="text" name="req_subject" size="80" maxlength="70" tabindex="<?php echo $cur_index++ ?>" value="<?php echo pun_htmlspecialchars(isset($_POST['req_subject']) ? $_POST['req_subject'] : $cur_post['subject']) ?>" /><br /></label>
 <?php endif; ?>						<label class="required"><strong><?php echo $lang_common['Message'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br />
-						<textarea name="req_message" rows="20" cols="95" tabindex="<?php echo $cur_index++ ?>"><?php echo pun_htmlspecialchars(isset($_POST['req_message']) ? $message : $cur_post['message']) ?></textarea><br /></label>
+						<textarea dir="auto" name="req_message" rows="20" cols="95" tabindex="<?php echo $cur_index++ ?>"><?php echo pun_htmlspecialchars(isset($_POST['req_message']) ? $message : $cur_post['message']) ?></textarea><br /></label>
 						<ul class="bblinks">
 							<li><span><a href="help.php#bbcode" onclick="window.open(this.href); return false;"><?php echo $lang_common['BBCode'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>
 							<li><span><a href="help.php#url" onclick="window.open(this.href); return false;"><?php echo $lang_common['url tag'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1' && $pun_user['g_post_links'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>

--- a/include/parser.php
+++ b/include/parser.php
@@ -749,15 +749,15 @@ function handle_list_tag($content, $type = '*')
 		);
 	}
 
-	$content = preg_replace('#\s*\[\*\](.*?)\[/\*\]\s*#s', '<li><p dir="auto">$1</p></li>', pun_trim($content));
+	$content = preg_replace('#\s*\[\*\](.*?)\[/\*\]\s*#s', '<li>$1</li>', pun_trim($content));
 
 	if ($type == '*')
-		$content = '<ul>'.$content.'</ul>';
+		$content = '<ul dir="auto">'.$content.'</ul>';
 	else
 		if ($type == 'a')
-			$content = '<ol class="alpha">'.$content.'</ol>';
+			$content = '<ol class="alpha" dir="auto">'.$content.'</ol>';
 		else
-			$content = '<ol class="decimal">'.$content.'</ol>';
+			$content = '<ol class="decimal" dir="auto">'.$content.'</ol>';
 
 	return '</p>'.$content.'<p dir="auto">';
 }

--- a/include/parser.php
+++ b/include/parser.php
@@ -772,11 +772,11 @@ function do_bbcode($text, $is_signature = false)
 
 	if (strpos($text, '[quote') !== false)
 	{
-		$text = preg_replace('%\[quote\]\s*%', '</p><div class="quotebox" dir="auto"><blockquote><div><p dir="auto">', $text);
+		$text = preg_replace('%\[quote\]\s*%', '</p><div class="quotebox"><blockquote><div><p dir="auto">', $text);
 		$text = preg_replace_callback(
 			'%\[quote=(&quot;|&\#039;|"|\'|)([^\r\n]*?)\\1\]%s',
 			function ($match) use ($lang_common) {
-				return '</p><div class="quotebox" dir="auto"><cite>'.
+				return '</p><div class="quotebox"><cite>'.
 					str_replace(array('[', '\"'), array('&#91;', '"'), $match[2]).
 					' '.$lang_common['wrote'].'</cite><blockquote><div><p dir="auto">';
 			},

--- a/include/parser.php
+++ b/include/parser.php
@@ -749,7 +749,7 @@ function handle_list_tag($content, $type = '*')
 		);
 	}
 
-	$content = preg_replace('#\s*\[\*\](.*?)\[/\*\]\s*#s', '<li><p>$1</p></li>', pun_trim($content));
+	$content = preg_replace('#\s*\[\*\](.*?)\[/\*\]\s*#s', '<li><p dir="auto">$1</p></li>', pun_trim($content));
 
 	if ($type == '*')
 		$content = '<ul>'.$content.'</ul>';
@@ -759,7 +759,7 @@ function handle_list_tag($content, $type = '*')
 		else
 			$content = '<ol class="decimal">'.$content.'</ol>';
 
-	return '</p>'.$content.'<p>';
+	return '</p>'.$content.'<p dir="auto">';
 }
 
 
@@ -772,17 +772,17 @@ function do_bbcode($text, $is_signature = false)
 
 	if (strpos($text, '[quote') !== false)
 	{
-		$text = preg_replace('%\[quote\]\s*%', '</p><div class="quotebox"><blockquote><div><p>', $text);
+		$text = preg_replace('%\[quote\]\s*%', '</p><div class="quotebox" dir="auto"><blockquote><div><p dir="auto">', $text);
 		$text = preg_replace_callback(
 			'%\[quote=(&quot;|&\#039;|"|\'|)([^\r\n]*?)\\1\]%s',
 			function ($match) use ($lang_common) {
-				return '</p><div class="quotebox"><cite>'.
+				return '</p><div class="quotebox" dir="auto"><cite>'.
 					str_replace(array('[', '\"'), array('&#91;', '"'), $match[2]).
-					' '.$lang_common['wrote'].'</cite><blockquote><div><p>';
+					' '.$lang_common['wrote'].'</cite><blockquote><div><p dir="auto">';
 			},
 			$text
 		);
-		$text = preg_replace('%\s*\[\/quote\]%S', '</p></div></blockquote></div><p>', $text);
+		$text = preg_replace('%\s*\[\/quote\]%S', '</p></div></blockquote></div><p dir="auto">', $text);
 	}
 	if (!$is_signature)
 	{
@@ -810,7 +810,7 @@ function do_bbcode($text, $is_signature = false)
 	$replace[] = '<ins>$1</ins>';
 	$replace[] = '<em>$1</em>';
 	$replace[] = '<span style="color: $1">$2</span>';
-	$replace[] = '</p><h5>$1</h5><p>';
+	$replace[] = '</p><h5 dir="auto">$1</h5><p dir="auto">';
 
 	if (($is_signature && $pun_config['p_sig_img_tag'] == '1') || (!$is_signature && $pun_config['p_message_img_tag'] == '1'))
 	{
@@ -953,7 +953,7 @@ function parse_message($text, $hide_smilies)
 			if (isset($inside[$i]))
 			{
 				$num_lines = (substr_count($inside[$i], "\n"));
-				$text .= '</p><div class="codebox"><pre'.(($num_lines > 28) ? ' class="vscroll"' : '').'><code>'.pun_trim($inside[$i], "\n\r").'</code></pre></div><p>';
+				$text .= '</p><div class="codebox"><pre'.(($num_lines > 28) ? ' class="vscroll"' : '').'><code>'.pun_trim($inside[$i], "\n\r").'</code></pre></div><p dir="auto">';
 			}
 		}
 	}
@@ -969,7 +969,7 @@ function clean_paragraphs($text)
 {
 	// Add paragraph tag around post, but make sure there are no empty paragraphs
 
-	$text = '<p>'.$text.'</p>';
+	$text = '<p dir="auto">'.$text.'</p>';
 
 	// Replace any breaks next to paragraphs so our replace below catches them
 	$text = preg_replace('%(</?p>)(?:\s*?<br />){1,2}%i', '$1', $text);
@@ -977,12 +977,15 @@ function clean_paragraphs($text)
 
 	// Remove any empty paragraph tags (inserted via quotes/lists/code/etc) which should be stripped
 	$text = str_replace('<p></p>', '', $text);
+	$text = str_replace('<p dir="auto"></p>', '', $text);
 
-	$text = preg_replace('%<br />\s*?<br />%i', '</p><p>', $text);
+	$text = preg_replace('%<br />\s*?<br />%i', '</p><p dir="auto">', $text);
 
-	$text = str_replace('<p><br />', '<br /><p>', $text);
+	$text = str_replace('<p><br />', '<br /><p dir="auto">', $text);
+	$text = str_replace('<p dir="auto"><br />', '<br /><p dir="auto">', $text);
 	$text = str_replace('<br /></p>', '</p><br />', $text);
 	$text = str_replace('<p></p>', '<br /><br />', $text);
+	$text = str_replace('<p dir="auto"></p>', '<br /><br />', $text);
 
 	return $text;
 }

--- a/misc.php
+++ b/misc.php
@@ -176,7 +176,7 @@ else if (isset($_GET['email']))
 						<label class="required"><strong><?php echo $lang_misc['Email subject'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br />
 						<input class="longinput" type="text" name="req_subject" size="75" maxlength="70" tabindex="1" /><br /></label>
 						<label class="required"><strong><?php echo $lang_misc['Email message'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br />
-						<textarea name="req_message" rows="10" cols="75" tabindex="2"></textarea><br /></label>
+						<textarea dir="auto" name="req_message" rows="10" cols="75" tabindex="2"></textarea><br /></label>
 						<p><?php echo $lang_misc['Email disclosure note'] ?></p>
 					</div>
 				</fieldset>
@@ -304,7 +304,7 @@ else if (isset($_GET['report']))
 					<legend><?php echo $lang_misc['Reason desc'] ?></legend>
 					<div class="infldset txtarea">
 						<input type="hidden" name="form_sent" value="1" />
-						<label class="required"><strong><?php echo $lang_misc['Reason'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br /><textarea name="req_reason" rows="5" cols="60"></textarea><br /></label>
+						<label class="required"><strong><?php echo $lang_misc['Reason'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br /><textarea dir="auto" name="req_reason" rows="5" cols="60"></textarea><br /></label>
 					</div>
 				</fieldset>
 			</div>

--- a/post.php
+++ b/post.php
@@ -663,7 +663,7 @@ if ($pun_user['is_guest'])
 if ($fid): ?>
 						<label class="required"><strong><?php echo $lang_common['Subject'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br /><input class="longinput" type="text" name="req_subject" value="<?php if (isset($_POST['req_subject'])) echo pun_htmlspecialchars($_POST['req_subject']); ?>" size="80" maxlength="70" tabindex="<?php echo $cur_index++ ?>" /><br /></label>
 <?php endif; ?>						<label class="required"><strong><?php echo $lang_common['Message'] ?> <span><?php echo $lang_common['Required'] ?></span></strong><br />
-						<textarea name="req_message" rows="20" cols="95" tabindex="<?php echo $cur_index++ ?>"><?php echo isset($_POST['req_message']) ? pun_htmlspecialchars($orig_message) : (isset($quote) ? $quote : ''); ?></textarea><br /></label>
+						<textarea dir="auto" name="req_message" rows="20" cols="95" tabindex="<?php echo $cur_index++ ?>"><?php echo isset($_POST['req_message']) ? pun_htmlspecialchars($orig_message) : (isset($quote) ? $quote : ''); ?></textarea><br /></label>
 						<ul class="bblinks">
 							<li><span><a href="help.php#bbcode" onclick="window.open(this.href); return false;"><?php echo $lang_common['BBCode'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>
 							<li><span><a href="help.php#url" onclick="window.open(this.href); return false;"><?php echo $lang_common['url tag'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1' && $pun_user['g_post_links'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>

--- a/profile.php
+++ b/profile.php
@@ -1578,7 +1578,7 @@ else
 							<p><?php echo $lang_profile['Signature info'] ?></p>
 							<div class="txtarea">
 								<label><?php printf($lang_profile['Sig max size'], forum_number_format($pun_config['p_sig_length']), $pun_config['p_sig_lines']) ?><br />
-								<textarea name="signature" rows="4" cols="65"><?php echo pun_htmlspecialchars($user['signature']) ?></textarea><br /></label>
+								<textarea dir="auto" name="signature" rows="4" cols="65"><?php echo pun_htmlspecialchars($user['signature']) ?></textarea><br /></label>
 							</div>
 							<ul class="bblinks">
 								<li><span><a href="help.php#bbcode" onclick="window.open(this.href); return false;"><?php echo $lang_common['BBCode'] ?></a> <?php echo ($pun_config['p_sig_bbcode'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>

--- a/style/Air.css
+++ b/style/Air.css
@@ -732,7 +732,6 @@ MAIN POSTS
 	float: right;
 	margin-right: -218px;
 	position: relative;
-	text-align: left;
 	width: 100%;
 }
 

--- a/style/Earth.css
+++ b/style/Earth.css
@@ -731,7 +731,6 @@ MAIN POSTS
 	float: right;
 	margin-right: -218px;
 	position: relative;
-	text-align: left;
 	width: 100%;
 }
 

--- a/style/Fire.css
+++ b/style/Fire.css
@@ -731,7 +731,6 @@ MAIN POSTS
 	float: right;
 	margin-right: -218px;
 	position: relative;
-	text-align: left;
 	width: 100%;
 }
 

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -456,7 +456,7 @@ else
 	echo "\t\t\t\t\t\t".'<label>';
 
 ?>
-<textarea name="req_message" rows="7" cols="75" tabindex="<?php echo $cur_index++ ?>"></textarea></label>
+<textarea dir="auto" name="req_message" rows="7" cols="75" tabindex="<?php echo $cur_index++ ?>"></textarea></label>
 						<ul class="bblinks">
 							<li><span><a href="help.php#bbcode" onclick="window.open(this.href); return false;"><?php echo $lang_common['BBCode'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>
 							<li><span><a href="help.php#url" onclick="window.open(this.href); return false;"><?php echo $lang_common['url tag'] ?></a> <?php echo ($pun_config['p_message_bbcode'] == '1' && $pun_user['g_post_links'] == '1') ? $lang_common['on'] : $lang_common['off']; ?></span></li>


### PR DESCRIPTION
Writing in LTR based forums is always a headache for people who use RTL languages. To add LTR/RTL support, we need to use auto direction (`dir="auto"`) to tags which can potentially include either of RTL or LTR text.

My commits handled this in two steps:
1. add `dir="auto"` to relevant tags in `parser.php` file
2. remove unnecessary `text-align: left` from styles` css.

Just notice that I have not been able to text the changes since I faced with difficulties for running FluxBB locally. But I don't think there would be any issue.

In order to verify changes, copy some RTL text in a post. You should see the paragraph starts with RTL character should go to the right and becomes RTL and paragraph (or heading or quotation) starting with English letters should remain as normal.