### PR TITLE
Resolve protocol relative URLs

### DIFF
--- a/include/parser.php
+++ b/include/parser.php
@@ -680,7 +680,9 @@ function handle_url_tag($url, $link = '', $bbcode = false)
 		$full_url = 'http://'.$full_url;
 	else if (strpos($url, 'ftp.') === 0) // Else if it starts with ftp, we add ftp://
 		$full_url = 'ftp://'.$full_url;
-	else if (strpos($url, '/') === 0) // Allow for relative URLs that start with a slash
+	else if (strpos($url, '//') === 0) // Allow for protocol relative URLs that start with a double slash
+		$full_url = get_current_protocol().':'.$full_url;
+	else if (strpos($url, '/') === 0) // Allow for host relative URLs that start with a slash
 		$full_url = get_base_url(true).$full_url;
 	else if (!preg_match('#^([a-z0-9]{3,6})://#', $url)) // Else if it doesn't start with abcdef://, we add http://
 		$full_url = 'http://'.$full_url;


### PR DESCRIPTION
Protocol relative URLs (PRURL) offer a convenient way for automatically resolving to the currently served protocol, e.g. http or https, without having to specify it explicitly. It is a great way of serving the content consistently on multi-protocol servers.

Many browsers can handle PRURLs natively, but FluxBB breaks such URLs as it doesn't recognise them correctly.

References:

* https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Examples_of_absolute_URLs
* https://en.wikipedia.org/wiki/URL#prurl