### PR TITLE
Apply flux_password_hash to new password

### DIFF
--- a/login.php
+++ b/login.php
@@ -165,7 +165,7 @@ else if ($action == 'forget' || $action == 'forget_2')
 					$new_password = random_pass(12);
 					$new_password_key = random_pass(8);
 
-					$db->query('UPDATE '.$db->prefix.'users SET activate_string=\''.pun_hash($new_password).'\', activate_key=\''.$new_password_key.'\', last_email_sent = '.time().' WHERE id='.$cur_hit['id']) or error('Unable to update activation data', __FILE__, __LINE__, $db->error());
+					$db->query('UPDATE '.$db->prefix.'users SET activate_string=\''.flux_password_hash($new_password).'\', activate_key=\''.$new_password_key.'\', last_email_sent = '.time().' WHERE id='.$cur_hit['id']) or error('Unable to update activation data', __FILE__, __LINE__, $db->error());
 
 					// Do the user specific replacements to the template
 					$cur_mail_message = str_replace('<username>', $cur_hit['username'], $mail_message);


### PR DESCRIPTION
#1147 The new password saved using the wrong hash, thus logging in with the new password would fail.

Thanks Visman for the code.