### PR TITLE
Modernize environment requirements and database layer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6.4"
+		"php": ">=7.4.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7"

--- a/db_update.php
+++ b/db_update.php
@@ -13,9 +13,9 @@ define('UPDATE_TO_DB_REVISION', 24);
 define('UPDATE_TO_SI_REVISION', 2);
 define('UPDATE_TO_PARSER_REVISION', 2);
 
-define('MIN_PHP_VERSION', '5.6.4');
-define('MIN_MYSQL_VERSION', '5.0.6');
-define('MIN_PGSQL_VERSION', '7.0.0');
+define('MIN_PHP_VERSION', '7.4.0');
+define('MIN_MYSQL_VERSION', '5.7.0');
+define('MIN_PGSQL_VERSION', '10.0.0');
 define('PUN_SEARCH_MIN_WORD', 3);
 define('PUN_SEARCH_MAX_WORD', 20);
 
@@ -303,8 +303,8 @@ function alter_table_utf8($table)
 		);
 	}
 
-	// Set table default charset to utf8
-	$db->query('ALTER TABLE '.$table.' CHARACTER SET utf8') or error('Unable to set table character set', __FILE__, __LINE__, $db->error());
+	// Set table default charset to utf8mb4
+	$db->query('ALTER TABLE '.$table.' CHARACTER SET utf8mb4') or error('Unable to set table character set', __FILE__, __LINE__, $db->error());
 
 	// Find out which columns need converting and build SQL statements
 	$result = $db->query('SHOW FULL COLUMNS FROM '.$table) or error('Unable to fetch column information', __FILE__, __LINE__, $db->error());
@@ -314,13 +314,13 @@ function alter_table_utf8($table)
 			continue;
 
 		list($type) = explode('(', $cur_column['Type']);
-		if (isset($types[$type]) && strpos($cur_column['Collation'], 'utf8') === false)
+		if (isset($types[$type]) && strpos($cur_column['Collation'], 'utf8mb4') === false)
 		{
 			$allow_null = ($cur_column['Null'] == 'YES');
-			$collate = (substr($cur_column['Collation'], -3) == 'bin') ? 'utf8_bin' : 'utf8_general_ci';
+			$collate = (substr($cur_column['Collation'], -3) == 'bin') ? 'utf8mb4_bin' : 'utf8mb4_general_ci';
 
 			$db->alter_field($table, $cur_column['Field'], preg_replace('%'.$type.'%i', $types[$type], $cur_column['Type']), $allow_null, $cur_column['Default'], null, true) or error('Unable to alter field to binary', __FILE__, __LINE__, $db->error());
-			$db->alter_field($table, $cur_column['Field'], $cur_column['Type'].' CHARACTER SET utf8 COLLATE '.$collate, $allow_null, $cur_column['Default'], null, true) or error('Unable to alter field to utf8', __FILE__, __LINE__, $db->error());
+			$db->alter_field($table, $cur_column['Field'], $cur_column['Type'].' CHARACTER SET utf8mb4 COLLATE '.$collate, $allow_null, $cur_column['Default'], null, true) or error('Unable to alter field to utf8mb4', __FILE__, __LINE__, $db->error());
 		}
 	}
 }
@@ -1548,12 +1548,12 @@ switch ($stage)
 					// Renaming a user also affects a bunch of other stuff, lets fix that too...
 					$db->query('UPDATE '.$db->prefix.'posts SET poster=\''.$db->escape($username).'\' WHERE poster_id='.$id) or error('Unable to update posts', __FILE__, __LINE__, $db->error());
 
-					// TODO: The following must compare using collation utf8_bin otherwise we will accidently update posts/topics/etc belonging to both of the duplicate users, not just the one we renamed!
-					$db->query('UPDATE '.$db->prefix.'posts SET edited_by=\''.$db->escape($username).'\' WHERE edited_by=\''.$db->escape($old_username).'\' COLLATE utf8_bin') or error('Unable to update posts', __FILE__, __LINE__, $db->error());
-					$db->query('UPDATE '.$db->prefix.'topics SET poster=\''.$db->escape($username).'\' WHERE poster=\''.$db->escape($old_username).'\' COLLATE utf8_bin') or error('Unable to update topics', __FILE__, __LINE__, $db->error());
-					$db->query('UPDATE '.$db->prefix.'topics SET last_poster=\''.$db->escape($username).'\' WHERE last_poster=\''.$db->escape($old_username).'\' COLLATE utf8_bin') or error('Unable to update topics', __FILE__, __LINE__, $db->error());
-					$db->query('UPDATE '.$db->prefix.'forums SET last_poster=\''.$db->escape($username).'\' WHERE last_poster=\''.$db->escape($old_username).'\' COLLATE utf8_bin') or error('Unable to update forums', __FILE__, __LINE__, $db->error());
-					$db->query('UPDATE '.$db->prefix.'online SET ident=\''.$db->escape($username).'\' WHERE ident=\''.$db->escape($old_username).'\' COLLATE utf8_bin') or error('Unable to update online list', __FILE__, __LINE__, $db->error());
+					// TODO: The following must compare using collation utf8mb4_bin otherwise we will accidently update posts/topics/etc belonging to both of the duplicate users, not just the one we renamed!
+					$db->query('UPDATE '.$db->prefix.'posts SET edited_by=\''.$db->escape($username).'\' WHERE edited_by=\''.$db->escape($old_username).'\' COLLATE utf8mb4_bin') or error('Unable to update posts', __FILE__, __LINE__, $db->error());
+					$db->query('UPDATE '.$db->prefix.'topics SET poster=\''.$db->escape($username).'\' WHERE poster=\''.$db->escape($old_username).'\' COLLATE utf8mb4_bin') or error('Unable to update topics', __FILE__, __LINE__, $db->error());
+					$db->query('UPDATE '.$db->prefix.'topics SET last_poster=\''.$db->escape($username).'\' WHERE last_poster=\''.$db->escape($old_username).'\' COLLATE utf8mb4_bin') or error('Unable to update topics', __FILE__, __LINE__, $db->error());
+					$db->query('UPDATE '.$db->prefix.'forums SET last_poster=\''.$db->escape($username).'\' WHERE last_poster=\''.$db->escape($old_username).'\' COLLATE utf8mb4_bin') or error('Unable to update forums', __FILE__, __LINE__, $db->error());
+					$db->query('UPDATE '.$db->prefix.'online SET ident=\''.$db->escape($username).'\' WHERE ident=\''.$db->escape($old_username).'\' COLLATE utf8mb4_bin') or error('Unable to update online list', __FILE__, __LINE__, $db->error());
 
 					// If the user is a moderator or an administrator we have to update the moderator lists
 					$result = $db->query('SELECT g_moderator FROM '.$db->prefix.'groups WHERE g_id='.$cur_user['group_id']) or error('Unable to fetch group', __FILE__, __LINE__, $db->error());

--- a/include/dblayer/mysqli.php
+++ b/include/dblayer/mysqli.php
@@ -51,7 +51,7 @@ class MysqlDBLayer implements DBLayer
 
 		// Setup the client-server character set (UTF-8)
 		if (!defined('FORUM_NO_SET_NAMES'))
-			$this->set_names('utf8');
+			$this->set_names('utf8mb4');
 	}
 
 
@@ -263,7 +263,7 @@ class MysqlDBLayer implements DBLayer
 			$query .= $field_name.' '.$field_data['datatype'];
 
 			if (isset($field_data['collation']))
-				$query .= 'CHARACTER SET utf8 COLLATE utf8_'.$field_data['collation'];
+				$query .= 'CHARACTER SET utf8mb4 COLLATE utf8mb4_'.$field_data['collation'];
 
 			if (!$field_data['allow_null'])
 				$query .= ' NOT NULL';
@@ -293,7 +293,7 @@ class MysqlDBLayer implements DBLayer
 		}
 
 		// We remove the last two characters (a newline and a comma) and add on the ending
-		$query = substr($query, 0, strlen($query) - 2)."\n".') ENGINE = '.(isset($schema['ENGINE']) ? $schema['ENGINE'] : 'MyISAM').' CHARACTER SET utf8';
+		$query = substr($query, 0, strlen($query) - 2)."\n".') ENGINE = '.(isset($schema['ENGINE']) ? $schema['ENGINE'] : 'InnoDB').' CHARACTER SET utf8mb4';
 
 		return $this->query($query) ? true : false;
 	}

--- a/include/dblayer/mysqli_innodb.php
+++ b/include/dblayer/mysqli_innodb.php
@@ -52,7 +52,7 @@ class MysqlInnodbDBLayer implements DBLayer
 
 		// Setup the client-server character set (UTF-8)
 		if (!defined('FORUM_NO_SET_NAMES'))
-			$this->set_names('utf8');
+			$this->set_names('utf8mb4');
 	}
 
 
@@ -276,7 +276,7 @@ class MysqlInnodbDBLayer implements DBLayer
 			$query .= $field_name.' '.$field_data['datatype'];
 
 			if (isset($field_data['collation']))
-				$query .= 'CHARACTER SET utf8 COLLATE utf8_'.$field_data['collation'];
+				$query .= 'CHARACTER SET utf8mb4 COLLATE utf8mb4_'.$field_data['collation'];
 
 			if (!$field_data['allow_null'])
 				$query .= ' NOT NULL';
@@ -306,7 +306,7 @@ class MysqlInnodbDBLayer implements DBLayer
 		}
 
 		// We remove the last two characters (a newline and a comma) and add on the ending
-		$query = substr($query, 0, strlen($query) - 2)."\n".') ENGINE = '.(isset($schema['ENGINE']) ? $schema['ENGINE'] : 'InnoDB').' CHARACTER SET utf8';
+		$query = substr($query, 0, strlen($query) - 2)."\n".') ENGINE = '.(isset($schema['ENGINE']) ? $schema['ENGINE'] : 'InnoDB').' CHARACTER SET utf8mb4';
 
 		return $this->query($query) ? true : false;
 	}

--- a/include/dblayer/sqlite.php
+++ b/include/dblayer/sqlite.php
@@ -7,8 +7,8 @@
  */
 
 // Make sure we have built in support for SQLite
-if (!function_exists('sqlite_open'))
-	exit('This PHP environment doesn\'t have SQLite support built in. SQLite support is required if you want to use a SQLite database to run this forum. Consult the PHP documentation for further assistance.');
+if (!class_exists('SQLite3'))
+	exit('This PHP environment doesn\'t have SQLite3 support built in. SQLite3 support is required if you want to use a SQLite database to run this forum. Consult the PHP documentation for further assistance.');
 
 
 require_once PUN_ROOT.'include/dblayer/interface.php';
@@ -55,13 +55,15 @@ class SqliteDBLayer implements DBLayer
 		if (!forum_is_writable($db_name))
 			error('Unable to open database \''.$db_name.'\' for writing. Permission denied', __FILE__, __LINE__);
 
-		if ($p_connect)
-			$this->link_id = @sqlite_popen($db_name, 0666, $sqlite_error);
-		else
-			$this->link_id = @sqlite_open($db_name, 0666, $sqlite_error);
-
-		if (!$this->link_id)
-			error('Unable to open database \''.$db_name.'\'. SQLite reported: '.$sqlite_error, __FILE__, __LINE__);
+		try
+		{
+			$this->link_id = new SQLite3($db_name);
+			$this->link_id->busyTimeout(5000);
+		}
+		catch (Exception $e)
+		{
+			error('Unable to open database \''.$db_name.'\'. SQLite reported: '.$e->getMessage(), __FILE__, __LINE__);
+		}
 	}
 
 
@@ -69,7 +71,7 @@ class SqliteDBLayer implements DBLayer
 	{
 		++$this->in_transaction;
 
-		return (@sqlite_query($this->link_id, 'BEGIN')) ? true : false;
+		return (@$this->link_id->exec('BEGIN')) ? true : false;
 	}
 
 
@@ -77,11 +79,11 @@ class SqliteDBLayer implements DBLayer
 	{
 		--$this->in_transaction;
 
-		if (@sqlite_query($this->link_id, 'COMMIT'))
+		if (@$this->link_id->exec('COMMIT'))
 			return true;
 		else
 		{
-			@sqlite_query($this->link_id, 'ROLLBACK');
+			@$this->link_id->exec('ROLLBACK');
 			return false;
 		}
 	}
@@ -92,10 +94,7 @@ class SqliteDBLayer implements DBLayer
 		if (defined('PUN_SHOW_QUERIES'))
 			$q_start = microtime(true);
 
-		if ($unbuffered)
-			$this->query_result = @sqlite_unbuffered_query($this->link_id, $sql);
-		else
-			$this->query_result = @sqlite_query($this->link_id, $sql);
+		$this->query_result = @$this->link_id->query($sql);
 
 		if ($this->query_result)
 		{
@@ -111,11 +110,11 @@ class SqliteDBLayer implements DBLayer
 			if (defined('PUN_SHOW_QUERIES'))
 				$this->saved_queries[] = array($sql, 0);
 
-			$this->error_no = @sqlite_last_error($this->link_id);
-			$this->error_msg = @sqlite_error_string($this->error_no);
+			$this->error_no = @$this->link_id->lastErrorCode();
+			$this->error_msg = @$this->link_id->lastErrorMsg();
 
 			if ($this->in_transaction)
-				@sqlite_query($this->link_id, 'ROLLBACK');
+				@$this->link_id->exec('ROLLBACK');
 
 			--$this->in_transaction;
 
@@ -128,10 +127,14 @@ class SqliteDBLayer implements DBLayer
 	{
 		if ($query_id)
 		{
-			if ($row !== 0 && @sqlite_seek($query_id, $row) === false)
-				return false;
+			if ($row !== 0)
+			{
+				$query_id->reset();
+				for ($i = 0; $i < $row; $i++)
+					$query_id->fetchArray(SQLITE3_NUM);
+			}
 
-			$cur_row = @sqlite_current($query_id);
+			$cur_row = @$query_id->fetchArray(SQLITE3_NUM);
 			if ($cur_row === false)
 				return false;
 
@@ -146,7 +149,7 @@ class SqliteDBLayer implements DBLayer
 	{
 		if ($query_id)
 		{
-			$cur_row = @sqlite_fetch_array($query_id, SQLITE_ASSOC);
+			$cur_row = @$query_id->fetchArray(SQLITE3_ASSOC);
 			if ($cur_row)
 			{
 				// Horrible hack to get rid of table names and table aliases from the array keys
@@ -171,25 +174,32 @@ class SqliteDBLayer implements DBLayer
 
 	function fetch_row($query_id = 0)
 	{
-		return ($query_id) ? @sqlite_fetch_array($query_id, SQLITE_NUM) : false;
+		return ($query_id) ? @$query_id->fetchArray(SQLITE3_NUM) : false;
 	}
 
 
 	function has_rows($query_id)
 	{
-		return $query_id ? sqlite_num_rows($query_id) > 0 : false;
+		if (!$query_id)
+			return false;
+
+		$query_id->reset();
+		$row = @$query_id->fetchArray(SQLITE3_NUM);
+		$query_id->reset();
+
+		return $row !== false;
 	}
 
 
 	function affected_rows()
 	{
-		return ($this->link_id) ? @sqlite_changes($this->link_id) : false;
+		return ($this->link_id) ? @$this->link_id->changes() : false;
 	}
 
 
 	function insert_id()
 	{
-		return ($this->link_id) ? @sqlite_last_insert_rowid($this->link_id) : false;
+		return ($this->link_id) ? @$this->link_id->lastInsertRowID() : false;
 	}
 
 
@@ -207,13 +217,15 @@ class SqliteDBLayer implements DBLayer
 
 	function free_result($query_id = false)
 	{
+		if ($query_id)
+			@$query_id->finalize();
 		return true;
 	}
 
 
 	function escape($str)
 	{
-		return is_array($str) ? '' : sqlite_escape_string($str);
+		return is_array($str) ? '' : SQLite3::escapeString($str);
 	}
 
 
@@ -236,10 +248,10 @@ class SqliteDBLayer implements DBLayer
 				if (defined('PUN_SHOW_QUERIES'))
 					$this->saved_queries[] = array('COMMIT', 0);
 
-				@sqlite_query($this->link_id, 'COMMIT');
+				@$this->link_id->exec('COMMIT');
 			}
 
-			return @sqlite_close($this->link_id);
+			return @$this->link_id->close();
 		}
 		else
 			return false;
@@ -260,9 +272,10 @@ class SqliteDBLayer implements DBLayer
 
 	function get_version()
 	{
+		$version = SQLite3::version();
 		return array(
 			'name'		=> 'SQLite',
-			'version'	=> sqlite_libversion()
+			'version'	=> $version['versionString']
 		);
 	}
 

--- a/install.php
+++ b/install.php
@@ -13,9 +13,9 @@ define('FORUM_DB_REVISION', 24);
 define('FORUM_SI_REVISION', 2);
 define('FORUM_PARSER_REVISION', 2);
 
-define('MIN_PHP_VERSION', '5.6.4');
-define('MIN_MYSQL_VERSION', '5.0.6');
-define('MIN_PGSQL_VERSION', '7.0.0');
+define('MIN_PHP_VERSION', '7.4.0');
+define('MIN_MYSQL_VERSION', '5.7.0');
+define('MIN_PGSQL_VERSION', '10.0.0');
 define('PUN_SEARCH_MIN_WORD', 3);
 define('PUN_SEARCH_MAX_WORD', 20);
 

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ of the other forums have whilst not sacrificing essential functionality or usabi
 ## Requirements
 
 * A webserver
-* PHP 5.6.4 or later
-* A database such as MySQL 5.0.6 or later, PostgreSQL 7.0 or later, or SQLite 2
+* PHP 7.4.0 or later
+* A database such as MySQL 5.7.0 or later, PostgreSQL 10.0 or later, or SQLite 3
 
 ## Recommendations
 


### PR DESCRIPTION
Security and compatibility improvements:

- Update minimum PHP version from 5.6.4 to 7.4.0
  - PHP 5.6 reached end-of-life in 2018
  - PHP 7.4 provides improved security and performance

- Update minimum MySQL version from 5.0.6 to 5.7.0
  - MySQL 5.0 reached end-of-life in 2012
  - Required for full utf8mb4 support

- Update minimum PostgreSQL version from 7.0.0 to 10.0.0
  - PostgreSQL 7.0 reached end-of-life in 2010
  - Modern version with better security and features

- Migrate from SQLite2 to SQLite3
  - SQLite2 extension removed in PHP 7.4
  - Complete rewrite of include/dblayer/sqlite.php
  - Use SQLite3 class and modern API

- Migrate character set from utf8 to utf8mb4
  - utf8 in MySQL only supports 3-byte characters (BMP only)
  - utf8mb4 supports full UTF-8 including emoji and 4-byte characters
  - Update all database layer files and migration scripts
  - Update collations from utf8_bin/utf8_general_ci to utf8mb4_bin/utf8mb4_general_ci

- Change default storage engine from MyISAM to InnoDB
  - InnoDB is the modern default with transaction support
  - Better crash recovery and foreign key support
  - Update include/dblayer/mysqli.php default engine

Files modified:
- readme.md: Update requirements documentation
- composer.json: Update PHP version requirement
- install.php: Update minimum version constants
- db_update.php: Update minimum versions and utf8mb4 migration
- include/dblayer/mysqli.php: utf8mb4 charset, InnoDB engine
- include/dblayer/mysqli_innodb.php: utf8mb4 charset
- include/dblayer/sqlite.php: Complete SQLite3 migration